### PR TITLE
Create config.schema.json

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,156 @@
+{
+  "pluginAlias": "Awair",
+  "pluginType": "accessory",
+  "singular": false,
+  "headerDisplay": "Awair plug-in for [Homebridge](https://github.com/nfarina/homebridge) using the native Awair API. Reference [Installation Instructions](https://github.com/deanlyoung/homebridge-awair#readme) for details on determining 'Developer Token' and 'Device ID'.",
+  "footerDisplay": "If you have multiple Awair devices, use those IDs to create individual accessories. Be sure to uniquely 'name' each device.",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "title": "Accessory Name (REQUIRED)",
+        "type": "string",
+        "default": "Awair",
+        "description": "The accessory name that appears by default in HomeKit."
+      },
+      "token": {
+        "title": "Developer Token (REQUIRED)",
+        "type": "string",
+        "placeholder": "AAA.AAA.AAA",
+        "description": "Reference Installation Instructions - link provided above."
+      },
+      "devType": {
+        "title": "Device Type (REQUIRED)",
+        "type": "string",
+        "default": "awair",
+        "enum": ["awair", "awair-glow", "awair-mint", "awair-omni","awair-r2", "awair-element"],
+        "description": "Device Type. (Options: `awair`, `awair-glow`, `awair-mint`, `awair-omni`, `awair-r2`, or 'awair-element')"
+      },
+      "devId": {
+        "title": "Device ID (REQUIRED)",
+        "type": "integer",
+        "placeholder": 123,
+        "description": "Reference Installation Instructions - link provided above."
+      },
+      "manufacturer": {
+        "title": "Manufacturer",
+        "type": "string",
+        "placeholder": "Awair",
+        "description": "Manufacturer, default = `Awair`"
+      },
+      "model": {
+        "title": "Device Model",
+        "type": "string",
+        "placeholder": "Device Type",
+        "description": "Default = Device Type, Options: `Awair`, `Awair Glow`, `Awair Mint`, `Awair Omni`, `Awair 2nd Edition`, or 'Awair Element'.",
+        "typeahead": {
+          "source": ["Awair", "Awair Glow", "Awair Mint", "Awair Onni", "Awair 2nd Edition", "Awair Element"]
+        }
+      },
+      "serial": {
+        "title": "Serial Number",
+        "type": "string",
+        "placeholder": "'Device Type'_'Device ID'",
+        "description": "Default = 'Device Type'_'Device ID', Options: `mac-address` or `devType'_'devId`."
+      },
+      "carbonDioxideThreshold": {
+        "title": "Carbon Dioxide Threshold",
+        "type": "integer",
+        "placeholder": 0,
+        "description": "The CO2 level at which HomeKit will trigger an alert for the CO2 in ppm. Default = 0 [OFF]."
+      },
+      "carbonDioxideThresholdOff": {
+        "title": "Carbon Dioxide Threshold",
+        "type": "integer",
+        "placeholder": 0,
+        "description": "The CO2 level at which HomeKit will turn off the trigger alert for the CO2 in ppm, to ensure that it doesn't trigger on/off too frequently choose a number lower than `carbonDioxideThreshold`. Default = 0."
+      },
+      "voc_mixture_mw": {
+        "title": "Reference Gas Molecular Weight",
+        "type": "number",
+        "placeholder": 72.66578273019740,
+        "readonly": true,
+        "description": "The Molecular Weight (g/mol) of a reference gas or mixture that you use to convert from ppb to ug/m^3."
+      },
+      "air_quality_method": {
+        "title": "Air quality calculation method",
+        "type": "string",
+        "placeholder": "awair-score",
+        "description": "Air quality calculation method used to define the Air Quality Chracteristic. Default = `awair-score`, Options: 'awair-score', `aqi`, or `nowcast-aqi`.",
+        "typeahead": {
+          "source": ["awair-score", "aqi", "nowcast-aq"]
+        }
+      },
+      "endpoint": {
+        "title": "The `air-data` endpoint",
+        "type": "string",
+        "placeholder": "15-min-avg",
+        "description": "The `air-data` endpoint to use. Default = '15-min-avg', Options: '15-min-avg', `5-min-avg`, `raw`, or `latest`.",
+        "typeahead": {
+          "source": ["15-min-avg", "5-min-avg", "raw", "latest"]
+        }
+      },
+      "polling": {
+        "title": "Polling frequency",
+        "type": "integer",
+        "placeholder": 900,
+        "description": "The frequency (units: seconds) that you would like to update the data in HomeKit. Default = `900` [15 minutes]."
+      },
+      "userType": {
+        "title": "The type of user account",
+        "type": "string",
+        "placeholder": "users/self",
+        "description": "The type of user account. Default = 'users/self', Options: 'users/self' or `orgs/###`, where ### is the Awair Organization `orgId'."
+      },
+      "limit": {
+        "title": "Data Points Returned",
+        "type": "integer",
+        "default": 12,
+        "description": "Number of consecutive 10 second data points returned per request, used for custom averaging of sensor values from `/raw` endpoint. (Default = `12` [2 minute average]"
+      },
+      "url": {
+        "title": "The Awair url to poll (EDITING NOT RECOMMENDED)",
+        "type": "string",
+        "readonly": true,
+        "default": "http://developer-apis.awair.is/v1/users/self/devices/:device_type/:device_id/air-data/:endpoint?limit=:limit&desc=true"
+      },
+      "logging": {
+        "title": " Whether to output logs to the Homebridge logs",
+        "type": "boolean",
+        "default": false
+      }
+    },
+    "required": ["name", "token", "devType", "devId"]
+  },
+  "layout": [
+    "name",
+    {
+      "type": "flex",
+      "flex-flow": "row wrap",
+      "items": ["token"]
+    },
+    "devType",
+    "devId",
+    {
+      "type": "fieldset",
+      "title": "Optional Configuration Settings",
+      "expandable": true,
+      "expanded": false,
+      "items": [
+        "manufacturer",
+        "model",
+        "serial",
+        "carbonDioxideThreshold",
+        "carbonDioxideThresholdOff",
+        "voc_mixture_mw",
+        "air_quality_method",
+        "endpoint",
+        "polling",
+        "userType",
+        "limit",
+        "url",
+        "logging"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
'config.schema.json' is used the bite 'homebridge-config-ui-x' plug-in to provide web based configuration of the 'homebridge-awair' plug-in. Have confirmed operation with a single Awair 2nd Edition model. Option included in proposed file to provide support for multiple Awair devices.